### PR TITLE
GeoJSON出力時に確認済みのデータのみを出力する機能をつける

### DIFF
--- a/line_bot.ts
+++ b/line_bot.ts
@@ -48,10 +48,14 @@ function doPost(e) {
  *
  */
 function doGet(_) {
+    const params = _.values;
     let lastRow = sheetLocation.getLastRow();
     let sheetValues = sheetLocation.getRange(2, 2, lastRow, 6).getValues();
     let json = [];
     for (let x = 0; x < sheetValues.length; x++) {
+        if (params.confirmed && sheetValues[x][4] !== "確認済み") {
+            continue;
+        }
         json.push({
             "latitude": sheetValues[x][0],
             "longitude": sheetValues[x][1],


### PR DESCRIPTION
- confirmedが「確認済み」のrowだけをGeoJSONで返す機能をつける
- `?confirmed=true` のようなリクエストが来た場合だけ確認済みrowだけをGeoJSONで返す