### PR TITLE
spreadsheetから取得するカラム数が足りていなかったのを修正

### DIFF
--- a/line_bot.ts
+++ b/line_bot.ts
@@ -62,7 +62,7 @@ function doPost(e) {
 function doGet(_) {
     const params = _.parameter;
     let lastRow = sheetLocation.getLastRow();
-    let sheetValues = sheetLocation.getRange(2, 1, lastRow, 6).getValues();
+    let sheetValues = sheetLocation.getRange(2, 1, lastRow, 8).getValues();
     let json = [];
     for (let x = 0; x < sheetValues.length; x++) {
         if (params.confirmed && sheetValues[x][COLUMN_confirmed-1] !== "確認済み") {


### PR DESCRIPTION
GHP2020-チームD-LINEBot入力 - Google スプレッドシート  https://docs.google.com/spreadsheets/d/1HEPFQ61MRltOwFIv8NM022ogmEu9Gywu1qkHiqfAAPc/edit#gid=1539080418

nameとname:enを返すには8列目まで取得する必要がある